### PR TITLE
Enable unfiltered shutil.unpack_archive for older versions of Py3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "radas"
 # Version is year.month.version
-version = "2024.7.0"
+version = "2024.7.1"
 description = "Plasma radiated power calculated using OpenADAS"
 authors = ["Commonwealth Fusion Systems"]
 readme = "README.md"

--- a/radas/adas_interface/prepare_adas_readers.py
+++ b/radas/adas_interface/prepare_adas_readers.py
@@ -2,7 +2,7 @@ import urllib.request
 import shutil
 from pathlib import Path
 from .compile_with_f2py import compile_with_f2py
-from warnings import warn
+import sys
 
 
 def prepare_adas_fortran_interface(reader_dir: Path, config: dict, verbose: int):
@@ -79,11 +79,13 @@ def build_adas_file_reader(
         if verbose:
             print(f"Unpacking {output_filename} into {output_folder}")
         
-        try:
+        if sys.version_info >= (3, 9, 17):
+            # If available, use the more secure 'filter' method
             shutil.unpack_archive(output_filename, output_folder, filter="data")
-        except TypeError:
-            warn(f"Ignoring unsupported 'filter' argument for shutil.unpack_archive. This is a potential security risk — we suggest to update your Python version (see https://peps.python.org/pep-0706/)")
+        else:
+            # The 'filter' argument was added in https://www.python.org/downloads/release/python-3917/
             shutil.unpack_archive(output_filename, output_folder)
+        
     else:
         if verbose:
             print(f"Reusing {query_path} ({output_filename} already exists)")

--- a/radas/adas_interface/prepare_adas_readers.py
+++ b/radas/adas_interface/prepare_adas_readers.py
@@ -2,6 +2,7 @@ import urllib.request
 import shutil
 from pathlib import Path
 from .compile_with_f2py import compile_with_f2py
+from warnings import warn
 
 
 def prepare_adas_fortran_interface(reader_dir: Path, config: dict, verbose: int):
@@ -77,7 +78,12 @@ def build_adas_file_reader(
         urllib.request.urlretrieve(query_path, output_filename)
         if verbose:
             print(f"Unpacking {output_filename} into {output_folder}")
-        shutil.unpack_archive(output_filename, output_folder, filter="data")
+        
+        try:
+            shutil.unpack_archive(output_filename, output_folder, filter="data")
+        except TypeError:
+            warn(f"Ignoring unsupported 'filter' argument for shutil.unpack_archive. This is a potential security risk — we suggest to update your Python version (see https://peps.python.org/pep-0706/)")
+            shutil.unpack_archive(output_filename, output_folder)
     else:
         if verbose:
             print(f"Reusing {query_path} ({output_filename} already exists)")


### PR DESCRIPTION
Fix for #13 