### PR TITLE
Add 0.5ms*n20 to ne_tau, add deuterium, tritium and boron to config

### DIFF
--- a/radas/adas_interface/download_adas_datasets.py
+++ b/radas/adas_interface/download_adas_datasets.py
@@ -14,15 +14,23 @@ def download_species_data(
     """Downloads all of the data files for a specific species."""
     data_file_dir.mkdir(exist_ok=True, parents=True)
 
-    for dataset_type, year in species_config["data_files"].items():
+    for dataset_type, file_to_download in species_config["data_files"].items():
 
         reader_class, dataset_config = determine_reader_class_and_config(
             data_file_config, dataset_type
         )
 
+        if isinstance(file_to_download, int):
+            species_key = species_config["atomic_symbol"].lower()
+            year = file_to_download
+        elif isinstance(file_to_download, list) and len(file_to_download) == 2:
+            species_key = file_to_download[0].lower()
+            year = file_to_download[1]
+        else:
+            raise NotImplementedError(f"Could not process entry: {file_to_download} for {species_name} {dataset_type}")
+
         year_key = f"{year}"[-2:]
         dataset_prefix = dataset_config["prefix"].lower()
-        species_key = species_config["atomic_symbol"].lower()
 
         output_filename = data_file_dir / f"{species_name}_{dataset_type}.dat"
         query_path = f"{url_base}/download/{reader_class}/{dataset_prefix}{year_key}/{dataset_prefix}{year_key}_{species_key}.dat"

--- a/radas/config.yaml
+++ b/radas/config.yaml
@@ -10,7 +10,7 @@ globals:
 
   # electron density (ne) * residence time (tau) (in m^-3 s)
   ne_tau:
-    value: [1.00000000e+16, 1.00000000e+17, 1.00000000e+18, 1.00000000e+19]
+    value: [1.0e+16, 0.5e+17, 1.0e+17, 1.0e+18, 1.0e+19]
     units: "m^-3 s"
 
 data_file_config:
@@ -83,6 +83,7 @@ species:
     atomic_symbol: "H"
     atomic_number:  1
     data_files:
+      # For each dataset, give the year to use
       effective_recombination: 2012
       effective_ionisation: 2012
       line_emission_from_excitation: 2012
@@ -90,6 +91,31 @@ species:
       charge_exchange_cross_coupling: 1996
       charge_exchange_emission: 1996
       mean_ionisation_potential: 1996
+  deuterium:
+    atomic_symbol: "D"
+    atomic_number:  1
+    data_files:
+      # We can use a length-2 list to specific a different
+      # species as well as a year. Here, we use the hydrogen
+      # data for everything except the CX rates.
+      effective_recombination: ["H", 2012]
+      effective_ionisation: ["H", 2012]
+      line_emission_from_excitation: ["H", 2012]
+      recombination_and_bremsstrahlung: ["H", 2012]
+      charge_exchange_cross_coupling: 1996
+      charge_exchange_emission: 1996
+      mean_ionisation_potential: ["H", 1996]
+  tritium:
+    atomic_symbol: "T"
+    atomic_number:  1
+    data_files:
+      effective_recombination: ["H", 2012]
+      effective_ionisation: ["H", 2012]
+      line_emission_from_excitation: ["H", 2012]
+      recombination_and_bremsstrahlung: ["H", 2012]
+      charge_exchange_cross_coupling: 1996
+      charge_exchange_emission: 1996
+      mean_ionisation_potential: ["H", 1996]
   helium:
     atomic_symbol: "He"
     atomic_number:  2
@@ -126,6 +152,14 @@ species:
   boron:
     atomic_symbol: "B"
     atomic_number:  5
+    data_files:
+      effective_recombination: 1989
+      effective_ionisation: 1989
+      line_emission_from_excitation: 1989
+      recombination_and_bremsstrahlung: 1989
+      charge_exchange_cross_coupling: 1989
+      charge_exchange_emission: 1989
+      mean_ionisation_potential: 1989
   carbon:
     atomic_symbol: "C"
     atomic_number:  6


### PR DESCRIPTION
* Adds 0.5 s * 1e20 m^-3 to the default ne_tau values in the config. This matches a value from https://doi.org/10.1088/1741-4326/ad3970
* Adds deuterium, tritium and boron to the species list in the config
* Adds a small edit to allow the use of other species atomic data (i.e. hydrogen ionisation and recombination rates for deuterium)